### PR TITLE
windows: ビルド時のUnicodeDecodeErrorを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ ifeq ($(OS),Windows_NT)
     CP       ?= $(PYTHON3) $(top_dir)/tools/coreutils.py cp
     MKDIR    ?= $(PYTHON3) $(top_dir)/tools/coreutils.py mkdir
     FIND     ?= $(PYTHON3) $(top_dir)/tools/coreutils.py find
+
+    export PYTHONUTF8=1
 else
     top_dir := $(shell pwd)
     RM := rm

--- a/tools/generate_ipcstub.py
+++ b/tools/generate_ipcstub.py
@@ -285,7 +285,7 @@ struct {{ msg.name }}_reply_fields {{ "{" }}
     msgid_max = next_msg_id - 1
     text = template.render(msgid_max=msgid_max, **idl)
 
-    with open(args.out, "w", encoding="utf-8") as f:
+    with open(args.out, "w") as f:
         f.write(text)
 
 
@@ -300,7 +300,7 @@ def main():
     )
     args = parser.parse_args()
 
-    idl_text = open(args.idl, encoding="utf-8").read()
+    idl_text = open(args.idl).read()
 
     try:
         idl = IDLParser().parse(idl_text)

--- a/tools/generate_ipcstub.py
+++ b/tools/generate_ipcstub.py
@@ -285,7 +285,7 @@ struct {{ msg.name }}_reply_fields {{ "{" }}
     msgid_max = next_msg_id - 1
     text = template.render(msgid_max=msgid_max, **idl)
 
-    with open(args.out, "w") as f:
+    with open(args.out, "w", encoding="utf-8") as f:
         f.write(text)
 
 
@@ -300,7 +300,7 @@ def main():
     )
     args = parser.parse_args()
 
-    idl_text = open(args.idl).read()
+    idl_text = open(args.idl, encoding="utf-8").read()
 
     try:
         idl = IDLParser().parse(idl_text)


### PR DESCRIPTION
Pythonのバージョンによっては、`UnicodeDecodeError`エラーが出るようになっていた。
Pythonを [UTF-8モード](https://docs.python.org/3/library/os.html#utf8-mode) に強制することで修正。

```
PS C:\Users\seiya\microkernel-book> make
UPDATE build/consts.mk
IPCSTUB libs/common/ipcstub.h
Traceback (most recent call last):
  File "C:\Users\seiya\microkernel-book\tools\generate_ipcstub.py", line 324, in <module>
    main()
  File "C:\Users\seiya\microkernel-book\tools\generate_ipcstub.py", line 303, in main
    idl_text = open(args.idl).read()
  File "C:\Users\seiya\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 10: character maps to <undefined>
```