### PR TITLE
windows: Swift on Windows同梱のLLVMツールチェーンを避ける

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ ifeq ($(OS),Windows_NT)
     FIND     ?= $(PYTHON3) $(top_dir)/tools/coreutils.py find
 
     export PYTHONUTF8=1
+
+    ifeq ($(LLVM_PREFIX),)
+        # wingetでインストールされた次のLLVMツールチェーンを使う
+        # https://winget.run/pkg/LLVM/LLVM
+        LLVM_PREFIX = "C:/Program Files/llvm/bin/"
+    endif
 else
     top_dir := $(shell pwd)
     RM := rm


### PR DESCRIPTION
Swift on WindowsにはLLVMツールチェーンが同梱されており、Windowsアプリケーションのコンパイルに必要ない機能は削ぎ落とされているらしくHinaOSのビルドに失敗してしまう。

そこで、wingetでインストールされるLLVMツールチェーンをデフォルトで利用するようにしておくことで、知らないうちにSwiftの方を使うことのないようにする。

https://github.com/nuta/microkernel-book/discussions/4