### PR TITLE
ci: バグを避けるためにQEMUをダウングレードする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Chocolatey packages
-        run: choco install qemu --version=2023.8.2
+        run: choco install qemu --version=2023.5.31
       - name: Install pip packages
         run: py -m pip install --user -r tools/requirements.txt
       - name: make doctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Chocolatey packages
-        run: choco install qemu
+        run: choco install qemu --version=2023.8.2
       - name: Install pip packages
         run: py -m pip install --user -r tools/requirements.txt
       - name: make doctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Chocolatey packages
-        run: choco install qemu --version=2023.5.31
+        run: choco install qemu --version=2023.6.29
       - name: Install pip packages
         run: py -m pip install --user -r tools/requirements.txt
       - name: make doctor


### PR DESCRIPTION
新しめのQEMUでは、おそらくバグ (https://github.com/qemu/qemu/commit/b274c2388e9fcde75d60c6e7c7d8f888874b61b7 で修正済み) で`aclint`オプションを指定できなくなっている:

```
qemu-system-riscv32: Property 'virt-machine.aclint' not found
```

ダウングレードすれば動くはず。